### PR TITLE
Prevent the top window from shrinking too much

### DIFF
--- a/zoom.el
+++ b/zoom.el
@@ -148,7 +148,8 @@ used when this function is called via `advice-add'."
               ;; non-nil, that is, update only when a *meaningful* window
               ;; selection happens
               norecord)
-    (zoom--update)))
+    (zoom--update))
+  (if (window-minibuffer-p) (balance-windows)))
 
 (defun zoom--update ()
   "Update the window layout in the current frame."


### PR DESCRIPTION
+ Related issue
[the top window shrinks too much when a larger minibuffer appears](https://github.com/cyrus-and/zoom/issues/5)

+ Background
when having two split windows and opening new minibuffer, the top window will shrink too much.

+ Solution
when opening new minibuffer, invoke `balance-windows` and all the window will resized. 