### PR TITLE
Add a variable to control track mouse behavior

### DIFF
--- a/zoom.el
+++ b/zoom.el
@@ -167,7 +167,7 @@ The return value is used to determine if an update is needed."
 
   ;; TODO adding the window sizes here causes one spurious update because first
   ;; the selected window is changed then the resize happens
-  (format "%s" (list track-mouse
+  (format "%s" (list (default-value 'track-mouse)
                      (mapcar (lambda (window) (list window
                                                     (window-total-width)
                                                     (window-total-height)))
@@ -187,7 +187,7 @@ Argument IGNORED is ignored."
       (with-selected-window
           (if (or (equal (selected-window) zoom--last-window)
                   (and zoom-minibuffer-preserve-layout (window-minibuffer-p))
-                  track-mouse)
+                  (default-value 'track-mouse))
               zoom--last-window
             ;; XXX this can't be simply omitted because it's needed to address
             ;; the case where a window changes buffer from/to a ignored buffer

--- a/zoom.el
+++ b/zoom.el
@@ -107,13 +107,6 @@ than few lines."
   :type 'boolean
   :group 'zoom)
 
-(defcustom zoom-track-mouse-preserve-layout t
-  "Non-nil means that the layout is retained when the `track-mouse' is t.
-
-Otherwise, `track-mouse' is not taken into account."
-  :type 'boolean
-  :group 'zoom)
-
 ;;;###autoload
 (define-minor-mode zoom-mode
   "Perform `zoom' automatically as the selected window changes."
@@ -194,7 +187,7 @@ Argument IGNORED is ignored."
       (with-selected-window
           (if (or (equal (selected-window) zoom--last-window)
                   (and zoom-minibuffer-preserve-layout (window-minibuffer-p))
-                  (and zoom-track-mouse-preserve-layout track-mouse))
+                  track-mouse)
               zoom--last-window
             ;; XXX this can't be simply omitted because it's needed to address
             ;; the case where a window changes buffer from/to a ignored buffer

--- a/zoom.el
+++ b/zoom.el
@@ -107,6 +107,13 @@ than few lines."
   :type 'boolean
   :group 'zoom)
 
+(defcustom zoom-track-mouse-preserve-layout t
+  "Non-nil means that the layout is retained when the `track-mouse' is t.
+
+Otherwise, `track-mouse' is not taken into account."
+  :type 'boolean
+  :group 'zoom)
+
 ;;;###autoload
 (define-minor-mode zoom-mode
   "Perform `zoom' automatically as the selected window changes."
@@ -187,7 +194,7 @@ Argument IGNORED is ignored."
       (with-selected-window
           (if (or (equal (selected-window) zoom--last-window)
                   (and zoom-minibuffer-preserve-layout (window-minibuffer-p))
-                  track-mouse)
+                  (and zoom-track-mouse-preserve-layout track-mouse))
               zoom--last-window
             ;; XXX this can't be simply omitted because it's needed to address
             ;; the case where a window changes buffer from/to a ignored buffer


### PR DESCRIPTION
Zoom is not plays well with [lsp-ui](https://github.com/emacs-lsp/lsp-ui) (when `lsp-ui-doc-show-with-mouse` is t which is t by default). I dig a little and find out that `track-mouse` in zoom causes this issue. I comment out it and use it like that for a while but never encounter any issue, so I added a variable to disable track-mouse tracking.

I hope it will be useful for someone else too.