### PR TITLE
Support derived modes in zoom-ignored-major-modes

### DIFF
--- a/zoom.el
+++ b/zoom.el
@@ -230,6 +230,7 @@ Argument IGNORED is ignored."
    (window-minibuffer-p)
    ;; check against the major mode
    (member major-mode zoom-ignored-major-modes)
+   (derived-mode-p zoom-ignored-major-modes)
    ;; check against the buffer name
    (member (buffer-name) zoom-ignored-buffer-names)
    ;; check against the buffer name (using a regexp)


### PR DESCRIPTION
## Foreword

First of all thank you for this incredible tool, its been a few years
since I've been using it, and I've never looked back.

I ran into an issue that I lived with for a while but figured I could
try to improve it. Hopefully this PR finds you well.

## Problem

Emacs has a concept of derived and parent modes. The relationship
between these modes is often used to share configuration or show a
shared purpose.

`zoom-mode` does not support the use of these "parent" modes in
`zoom-ignored-major-modes`, instead it checks whether the current mode
is in that list of modes. One example would be a user who wants to
ignore all `gnus-mode` child modes; currently they would need to add
`gnus-summary-mode`, `gnus-group-mode`, and some of the other 20 odd
`^gnus-.*-mode$` modes. This is difficult to track and error prone.

## Solution

Instead of checking if the `major-mode` is in the
`zoom-ignored-major-modes` list check if it is a child of one of those
modes.

## Testing

I've tested with `gnus-mode` and found it to work as expected